### PR TITLE
Feature/minimum drag distance

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -7,9 +7,27 @@ const sliderElement = document.querySelector('.example-slider')
 const slides = sliderElement.getElementsByClassName('scroll-snap-slide')
 const slider = new ScrollSnapSlider(sliderElement)
 
+slider.roundingMethod = function (x) {
+  const direction = x <= slider.slide ? -1 : 1
+
+  if (direction < 0) {
+    return Math.floor(x)
+  }
+
+  return Math.ceil(x)
+}
+
+/**
+ * @param {Number} x the current slide position as a decimal (e.g. 1,5 = slide at index 1 has been slided by 50%)
+ */
+slider.roundingMethod = function (x) {
+  // TODO return an integer that will be the the slider.slide
+  return Math.round(x)
+}
+
 const autoplayPlugin = new ScrollSnapAutoplay()
 const loopPlugin = new ScrollSnapLoop()
-const draggablePlugin = new ScrollSnapDraggable()
+const draggablePlugin = new ScrollSnapDraggable(50)
 
 /** BUTTONS & INDICATORS **/
 const buttons = document.querySelectorAll('.example-indicator')

--- a/src/ScrollSnapDraggable.js
+++ b/src/ScrollSnapDraggable.js
@@ -1,7 +1,7 @@
 import { ScrollSnapPlugin } from './ScrollSnapPlugin.js'
 
 export class ScrollSnapDraggable extends ScrollSnapPlugin {
-  constructor (minimalDragDistance = null) {
+  constructor (quickSwipeDistance = null) {
     super()
 
     /**
@@ -25,7 +25,7 @@ export class ScrollSnapDraggable extends ScrollSnapPlugin {
      *
      * @type {?Number}
      */
-    this.minimalDragDistance = minimalDragDistance
+    this.quickSwipeDistance = quickSwipeDistance
 
     /**
      * Timeout ID for a smooth drag release
@@ -135,12 +135,12 @@ export class ScrollSnapDraggable extends ScrollSnapPlugin {
   }
 
   getFinalSlide () {
-    if (!this.minimalDragDistance) {
+    if (!this.quickSwipeDistance) {
       return this.slider.slide
     }
 
     const distance = Math.abs(this.startX - this.lastX)
-    const minimumNotReached = this.minimalDragDistance > distance
+    const minimumNotReached = this.quickSwipeDistance > distance
     const halfPointCrossed = distance > (this.element.offsetWidth / 2)
 
     if (minimumNotReached || halfPointCrossed) {

--- a/src/ScrollSnapDraggable.js
+++ b/src/ScrollSnapDraggable.js
@@ -11,14 +11,18 @@ export class ScrollSnapDraggable extends ScrollSnapPlugin {
     this.lastX = null
 
     /**
-     * When the dragging started
+     * Where the dragging started
      * @type {?Number}
      */
     this.startX = null
 
     /**
-     * If this is null, the next/previous slide will not be reached unless the scroll-snap offset has been reached.
-     * If this is a number, dragging any slide for more than this distance in pixels will slide to the next slide in the desired direction.
+     * If this is null:
+     *  The next/previous slide will not be reached unless you drag for more than half the slider's width.
+     *
+     * If this is a number:
+     *  Dragging any slide for more than this distance in pixels will slide to the next slide in the desired direction.
+     *
      * @type {?Number}
      */
     this.minimalDragDistance = minimalDragDistance


### PR DESCRIPTION
This adds a new parameter to the `ScrollSnapDraggable` Plugin:

```js
/**
 * If this is null:
 *  The next/previous slide will not be reached unless you drag for more than half the slider's width.
 *
 * If this is a number:
 *  Dragging any slide for more than this distance in pixels will slide to the next slide in the desired direction.
 *
 * @type {?Number}
 */
this.quickSwipeDistance
```

```js
const slider = new ScrollSnapSlider(sliderElement, true, [
  new ScrollSnapDraggable(50)
])
```