### PR TITLE
docs(fix): correctly import dependencies in plugin example

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,9 +194,7 @@ You can add one or multiple of the available Plugins:
   necessary for touch sliding.
 
 ```javascript
-import { ScrollSnapSlider } from 'scroll-snap-slider/src/ScrollSnapSlider.js'
-import { ScrollSnapAutoplay } from 'scroll-snap-slider/src/ScrollSnapAutoplay.js'
-import { ScrollSnapLoop } from 'scroll-snap-slider/src/ScrollSnapLoop.js'
+import { ScrollSnapSlider, ScrollSnapAutoplay, ScrollSnapLoop } from 'scroll-snap-slider';
 
 const element = document.querySelector('.example-slider')
 const slider = new ScrollSnapSlider({ element }).with([


### PR DESCRIPTION
The src dependencies are not available, since you only ship the `dist` folder. 
I adjusted the imports in the documentation to work like expected 👍 