### PR TITLE
fix(feat): correctly calculate last slide in autoplay plugin

### DIFF
--- a/src/ScrollSnapAutoplay.ts
+++ b/src/ScrollSnapAutoplay.ts
@@ -100,7 +100,9 @@ export class ScrollSnapAutoplay extends ScrollSnapPlugin {
 
     requestAnimationFrame(() => {
       const { scrollLeft, offsetWidth, scrollWidth } = this.slider.element
-      const isLastSlide = scrollLeft + offsetWidth === scrollWidth
+
+      // check if calculated scroll width is within 10px, since the numbers are a bit off sometimes
+      const isLastSlide = Math.abs((scrollLeft + offsetWidth) - scrollWidth) <= 10;
       const target = isLastSlide ? 0 : this.slider.slide + 1
 
       this.slider.slideTo(target)


### PR DESCRIPTION
When using the autoplay plugin, the calculation for the last slide did not work correctly, since the numbers where a bit off. 

`scrollLeft + offsetWidth: 5912.2724609375`
`scrollWidth: 5913`